### PR TITLE
fixed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Please ensure your pull request adheres to the following guidelines:
 * [Egghead.io](https://egghead.io/)
 * [Exercism](http://www.exercism.io)
 * [EXLskills](https://exlskills.com/)
+* [Flutter.io](https://flutter.io/tutorials/)
 * [Free Code Camp](https://www.freecodecamp.org/)
 * [Frontend Masters](https://frontendmasters.com/)
 * [Future Learn](https://www.futurelearn.com)
@@ -113,7 +114,6 @@ Please ensure your pull request adheres to the following guidelines:
 * [Just Javascript](https://justjavascript.com/)
 * [Khan Academy](https://www.khanacademy.org/)
 * [Leetcode](https://leetcode.com/)
-* [Linux Academy](https://linuxacademy.com/)
 * [Lynda.com](https://www.lynda.com/)
 * [Microsoft Virtual Academy](https://mva.microsoft.com)
 * [MIT OpenCourseWare](https://ocw.mit.edu/index.htm)
@@ -222,7 +222,6 @@ Please ensure your pull request adheres to the following guidelines:
 * [Academind - Flutter Tutorial for Beginners](https://www.youtube.com/watch?v=GLSG_Wh_YWc)
 * [Bram Vanbilsen - Flutter Crash Course - Building a Complete App From Scratch](https://www.youtube.com/watch?v=jBBl1tYkUnE)
 * [Ben Award - Flutter](https://www.youtube.com/playlist?list=PLN3n1USn4xlmO_0L_x12YDnpZTlI5uzaT)
-* [Flutter.io](https://flutter.io/tutorials/)
 
 ### GitHub
 


### PR DESCRIPTION
flutter.io was in the wrong section, now in websites alphabetically placed.
linuxacademy website is down or nonexistent  and the link redirects to a cloud guru which is already in websites section so linux academy was removed