### PR TITLE
Add Libre Academy to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Please ensure your pull request adheres to the following guidelines:
 - [Just Javascript](https://justjavascript.com/)
 - [Khan Academy](https://www.khanacademy.org/)
 - [Leetcode](https://leetcode.com/)
+- [Libre Academy](https://libre.academy)
 - [Linkedin Learning](https://www.linkedin.com/learning/)
 - [Microsoft Virtual Academy](https://mva.microsoft.com)
 - [MIT OpenCourseWare](https://ocw.mit.edu/index.htm)


### PR DESCRIPTION
Adds [Libre Academy](https://libre.academy) to the **Websites** section in alphabetical order (between Leetcode and Linkedin Learning), using the documented `[Site Name](link)` format.

Libre Academy is a free, open-source platform that provides interactive programming courses — learners write real code across 90+ courses in 26 languages, graded by hidden tests. Fits alongside the existing Codecademy / Class Central / Exercism entries.